### PR TITLE
[FIX] ormcache_redis: handle errors when the configuration is not set

### DIFF
--- a/modules/registry.py
+++ b/modules/registry.py
@@ -20,4 +20,5 @@ def cache(self):
     db_name = self.db_name
     return RedisLRU(r,db_name)
 
-Registry.cache = cache
+if odoo.tools.config.get('ormcache_redis_url'):
+    Registry.cache = cache


### PR DESCRIPTION
Current:
At now KeyError ormcache_redis_url will appear when configuration is not set

Expected:
Keyerror will not appear again when configuration is not set